### PR TITLE
docs: Update README to reflect v0.6.0 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Package license: Apache-2.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyhf-feedstock/blob/master/LICENSE.txt)
 
-Summary: (partial) pure Python HistFactory implementation
+Summary: pure-Python HistFactory implementation
 
 Development: https://github.com/scikit-hep/pyhf
 
-Documentation: https://scikit-hep.org/pyhf/
+Documentation: https://pyhf.readthedocs.io/
 
 The HistFactory p.d.f. template [CERN-OPEN-2012-016] is per-se independent
 of its implementation in ROOT and sometimes, it's useful to be able to run
@@ -130,8 +130,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@bdice](https://github.com/bdice/)
+* [@matthewfeickert](https://github.com/matthewfeickert/)
 * [@kratsg](https://github.com/kratsg/)
 * [@lukasheinrich](https://github.com/lukasheinrich/)
-* [@matthewfeickert](https://github.com/matthewfeickert/)
+* [@bdice](https://github.com/bdice/)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The HistFactory p.d.f. template [CERN-OPEN-2012-016] is per-se independent
 of its implementation in ROOT and sometimes, it's useful to be able to run
 statistical analysis outside of ROOT, RooFit, RooStats framework.
 
-This repo is a pure-python implementation of that statistical model for
+This repo is a pure-Python implementation of that statistical model for
 multi-bin histogram-based analysis and its interval estimation is based on
 the asymptotic formulas of "Asymptotic formulae for likelihood-based tests
 of new physics" [arXiv:1007.1727]. The aim is also to support modern

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - pyhf = pyhf.cli:cli


### PR DESCRIPTION
Update the README to reflected the state of the project as of v0.6.0

```
* Update README to show docs URL as of v0.6.0
* Bump build number as package version not being increased
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
