### PR TITLE
MNT: Remove 'pip install' options

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ build:
   noarch: python
   entry_points:
     - pyhf = pyhf.cli:cli
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 4
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 5
 
 requirements:
   host:


### PR DESCRIPTION
* Remove --no-deps --no-build-isolation 'pip install' options in recipes as the build tool (e.g. conda-build, rattler-build) will enforce all required 'pip install' options itself at build time.
   - c.f. https://github.com/conda/grayskull/issues/582
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
